### PR TITLE
Fix pluralization on pending items legend.

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       </form>
 
       <div v-if="pending.length > 0">
-        <p class="status busy">You have {{ pending.length }} pending item<span v-if="todoList.length>1">s</span></p>
+        <p class="status busy">You have {{ pending.length }} pending item<span v-if="pending.length>1">s</span></p>
         <transition-group name="todo-item" tag="ul" class="todo-list">
           <li v-for="(item, index) in pending" v-bind:key="item.title">
             <input class="todo-checkbox" v-bind:id="'item_' + item.id" v-model="item.done" type="checkbox">


### PR DESCRIPTION
Hi @nourabusoud, you did a great work with this todo-list. I'm learning Vue, and your work had helped me a ton.

I'm writing this pull request because I found a minor bug in your code. When the pending items count gets to one, the legend at the top of the list still uses the plural form to refer to the items. I'd noticed that you did take that into account, but the condition you use to do the check was wrong; instead of *todolist.length* should have been *pending.length*. I know it's a minor fix, but still.

Cheers, and keep up the good work! 

